### PR TITLE
Add the web-message crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["web-codecs", "web-streams", "web-async"]
+members = ["web-codecs", "web-streams", "web-async", "web-message"]

--- a/web-message-derive/Cargo.toml
+++ b/web-message-derive/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "web-message-derive"
+version = "0.0.1"
+edition = "2024"
+
+description = "A macro that converts Rust structs to/from JavaScript objects via postMessage."
+authors = ["Luke Curley"]
+repository = "https://github.com/kixelated/web-rs"
+license = "MIT OR Apache-2.0"
+
+categories = ["wasm", "web-programming"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/web-message-derive/src/lib.rs
+++ b/web-message-derive/src/lib.rs
@@ -1,0 +1,241 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Attribute, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, MetaNameValue, parse_macro_input};
+
+#[proc_macro_derive(Message, attributes(msg))]
+pub fn derive_message(input: TokenStream) -> TokenStream {
+	let input = parse_macro_input!(input as DeriveInput);
+	let ident = &input.ident;
+
+	let output = match &input.data {
+		syn::Data::Struct(data) => expand_struct(ident, &data.fields),
+		syn::Data::Enum(data_enum) => {
+			let tag_field = get_tag_field(&input.attrs).unwrap_or_else(|| {
+				panic!("#[derive(Message)] on enums requires #[msg(tag = \"type\")]");
+			});
+
+			expand_enum(ident, &tag_field, &data_enum.variants)
+		}
+		_ => panic!("Message only supports structs and enums"),
+	};
+
+	output.into()
+}
+
+fn get_tag_field(attrs: &[Attribute]) -> Option<String> {
+	for attr in attrs {
+		if attr.path().is_ident("msg") {
+			if let Ok(Meta::NameValue(MetaNameValue { path, value, .. })) = attr.parse_args() {
+				if path.is_ident("tag") {
+					if let Expr::Lit(ExprLit {
+						lit: Lit::Str(lit_str), ..
+					}) = value
+					{
+						return Some(lit_str.value());
+					}
+				}
+			}
+		}
+	}
+	None
+}
+
+fn expand_struct(ident: &syn::Ident, fields: &Fields) -> proc_macro2::TokenStream {
+	let field_inits = fields.iter().map(|f| {
+		let name = f.ident.as_ref().unwrap();
+		let name_str = name.to_string();
+
+		let is_transferable = f.attrs.iter().any(|attr| {
+			attr.path().is_ident("msg")
+				&& attr
+					.parse_args::<syn::Ident>()
+					.map_or(false, |ident| ident == "transferable")
+		});
+
+		if is_transferable {
+			quote! {
+				#name: ::js_sys::Reflect::get(&obj, &#name_str.into()).map_err(|_| ::web_message::Error::MissingField(#name_str))?
+					.into()
+			}
+		} else {
+			quote! {
+				#name: ::js_sys::Reflect::get(&obj, &#name_str.into()).map_err(|_| ::web_message::Error::MissingField(#name_str))?
+					.try_into()
+					.map_err(|_| ::web_message::Error::InvalidField(#name_str, ::js_sys::Reflect::get(&obj, &#name_str.into()).unwrap()))?
+			}
+		}
+	});
+
+	let field_assignments = fields.iter().map(|f| {
+		let name = f.ident.as_ref().unwrap();
+		let name_str = name.to_string();
+
+		let is_transferable = f.attrs.iter().any(|attr| {
+			attr.path().is_ident("msg")
+				&& attr
+					.parse_args::<syn::Ident>()
+					.map_or(false, |ident| ident == "transferable")
+		});
+
+		if is_transferable {
+			quote! {
+				::js_sys::Reflect::set(&obj, &#name_str.into(), &self.#name.clone().into()).unwrap();
+				transferable.push(&self.#name.into());
+			}
+		} else {
+			quote! {
+				::js_sys::Reflect::set(&obj, &#name_str.into(), &self.#name.into()).unwrap();
+			}
+		}
+	});
+
+	quote! {
+		impl #ident {
+			pub fn from_message(message: ::js_sys::wasm_bindgen::JsValue) -> Result<Self, ::web_message::Error> {
+				let obj = js_sys::Object::try_from(&message).ok_or(::web_message::Error::ExpectedObject(message.clone()))?;
+				Ok(Self {
+					#(#field_inits),*
+				})
+			}
+
+			pub fn into_message(self) -> (::js_sys::Object, ::js_sys::Array) {
+				let obj = ::js_sys::Object::new();
+				let transferable = ::js_sys::Array::new();
+				#(#field_assignments)*
+				(obj, transferable)
+			}
+		}
+	}
+}
+
+fn expand_enum(
+	enum_ident: &syn::Ident,
+	tag_field: &str,
+	variants: &syn::punctuated::Punctuated<syn::Variant, syn::token::Comma>,
+) -> proc_macro2::TokenStream {
+	let from_matches = variants.iter().map(|variant| {
+		let variant_ident = &variant.ident;
+		let variant_str = variant_ident.to_string();
+
+		match &variant.fields {
+			Fields::Named(fields_named) => {
+				let field_assignments = fields_named.named.iter().map(|f| {
+					let name = f.ident.as_ref().unwrap();
+					let name_str = name.to_string();
+
+					let is_transferable = f.attrs.iter().any(|attr| {
+						attr.path().is_ident("post")
+							&& attr
+								.parse_args::<syn::Ident>()
+								.map_or(false, |ident| ident == "transferable")
+					});
+
+					if is_transferable {
+						quote! {
+							#name: ::js_sys::Reflect::get(&obj, &#name_str.into()).map_err(|_| ::web_message::Error::MissingField(#name_str))?
+								.into()
+						}
+					} else {
+						quote! {
+							#name: ::js_sys::Reflect::get(&obj, &#name_str.into()).map_err(|_| ::web_message::Error::MissingField(#name_str))?
+								.try_into()
+								.map_err(|_| ::web_message::Error::InvalidField(#name_str, ::js_sys::Reflect::get(&obj, &#name_str.into()).unwrap()))?
+						}
+					}
+				});
+
+				quote! {
+					#variant_str => {
+						Ok(#enum_ident::#variant_ident {
+							#(#field_assignments),*
+						})
+					}
+				}
+			}
+
+			Fields::Unit => {
+				quote! {
+					#variant_str => Ok(#enum_ident::#variant_ident),
+				}
+			}
+
+			_ => unimplemented!("web-message does not support tuple variants (yet)"),
+		}
+	});
+
+	let into_matches = variants.iter().map(|variant| {
+		let variant_ident = &variant.ident;
+		let variant_str = variant_ident.to_string();
+
+		match &variant.fields {
+			Fields::Named(fields_named) => {
+				let field_names = fields_named.named.iter().map(|f| f.ident.as_ref().unwrap());
+
+				let set_fields = fields_named.named.iter().map(|f| {
+					let name = f.ident.as_ref().unwrap();
+					let name_str = name.to_string();
+
+					let is_transferable = f.attrs.iter().any(|attr| {
+						attr.path().is_ident("post")
+							&& attr
+								.parse_args::<syn::Ident>()
+								.map_or(false, |ident| ident == "transferable")
+					});
+
+					if is_transferable {
+						quote! {
+							::js_sys::Reflect::set(&obj, &#name_str.into(), &#name.clone().into()).unwrap();
+							transferable.push(&#name.into());
+						}
+					} else {
+						quote! {
+							::js_sys::Reflect::set(&obj, &#name_str.into(), &#name.into()).unwrap();
+						}
+					}
+				});
+
+				quote! {
+					#enum_ident::#variant_ident { #(#field_names),* } => {
+						::js_sys::Reflect::set(&obj, &#tag_field.into(), &#variant_str.into()).unwrap();
+						#(#set_fields)*
+					}
+				}
+			}
+			Fields::Unit => {
+				quote! {
+					#enum_ident::#variant_ident => {
+						::js_sys::Reflect::set(&obj, &#tag_field.into(), &#variant_str.into()).unwrap();
+					}
+				}
+			}
+			_ => unimplemented!("web-message does not support tuple variants (yet)"),
+		}
+	});
+
+	quote! {
+		impl #enum_ident {
+			pub fn from_message(message: ::js_sys::wasm_bindgen::JsValue) -> Result<Self, ::web_message::Error> {
+				let obj = js_sys::Object::try_from(&message).ok_or(::web_message::Error::ExpectedObject(message.clone()))?;
+				let tag_val = ::js_sys::Reflect::get(&obj, &#tag_field.into()).map_err(|_| ::web_message::Error::MissingTag(#tag_field))?;
+				let tag_str = tag_val.as_string()
+					.ok_or(::web_message::Error::InvalidTag(#tag_field, tag_val.clone()))?;
+
+				match tag_str.as_str() {
+					#(#from_matches)*
+					_ => Err(::web_message::Error::UnknownTag(#tag_field, tag_val.clone())),
+				}
+			}
+
+			pub fn into_message(self) -> (::js_sys::Object, ::js_sys::Array) {
+				let obj = ::js_sys::Object::new();
+				let transferable = ::js_sys::Array::new();
+
+				match self {
+					#(#into_matches),*
+				}
+
+				(obj, transferable)
+			}
+		}
+	}
+}

--- a/web-message/Cargo.toml
+++ b/web-message/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["wasm", "web-programming"]
 default = ["derive"]
 derive = ["dep:web-message-derive"]
 
+# These features implement the Message interface for popular crates:
+url = ["dep:url"]
+
 # These feature names copy web_sys for all (currently) transferable types.
 # https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects
 MessagePort = ["web-sys/MessagePort"]
@@ -33,3 +36,5 @@ MidiAccess = ["web-sys/MidiAccess"]
 web-message-derive = { path = "../web-message-derive", version = "0.0.1", optional = true }
 web-sys = "0.3"
 thiserror = "2"
+
+url = { version = "2", optional = true }

--- a/web-message/Cargo.toml
+++ b/web-message/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "web-message"
+version = "0.0.1"
+edition = "2024"
+description = "A macro that converts Rust structs to/from JavaScript objects via postMessage."
+authors = ["Luke Curley"]
+repository = "https://github.com/kixelated/web-rs"
+license = "MIT OR Apache-2.0"
+
+categories = ["wasm", "web-programming"]
+
+[features]
+default = ["derive"]
+derive = ["dep:web-message-derive"]
+
+[dependencies]
+web-message-derive = { path = "../web-message-derive", version = "0.0.1", optional = true }
+js-sys = "0.3"
+thiserror = "2"

--- a/web-message/Cargo.toml
+++ b/web-message/Cargo.toml
@@ -13,7 +13,23 @@ categories = ["wasm", "web-programming"]
 default = ["derive"]
 derive = ["dep:web-message-derive"]
 
+# These feature names copy web_sys for all (currently) transferable types.
+# https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects
+MessagePort = ["web-sys/MessagePort"]
+ReadableStream = ["web-sys/ReadableStream"]
+WritableStream = ["web-sys/WritableStream"]
+TransformStream = ["web-sys/TransformStream"]
+WebTransportReceiveStream = ["web-sys/WebTransportReceiveStream"]
+WebTransportSendStream = ["web-sys/WebTransportSendStream"]
+AudioData = ["web-sys/AudioData"]
+ImageBitmap = ["web-sys/ImageBitmap"]
+VideoFrame = ["web-sys/VideoFrame"]
+OffscreenCanvas = ["web-sys/OffscreenCanvas"]
+RtcDataChannel = ["web-sys/RtcDataChannel"]
+# MediaSourceHandle = ["web-sys/MediaSourceHandle"]
+MidiAccess = ["web-sys/MidiAccess"]
+
 [dependencies]
 web-message-derive = { path = "../web-message-derive", version = "0.0.1", optional = true }
-js-sys = "0.3"
+web-sys = "0.3"
 thiserror = "2"

--- a/web-message/src/derive.rs
+++ b/web-message/src/derive.rs
@@ -1,0 +1,56 @@
+pub use web_message_derive::Message;
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn to_from_enum() {
+		#[derive(Message, Clone, Debug, PartialEq, Eq)]
+		#[msg(tag = "command")]
+		enum Command {
+			Init {
+				width: u64,
+				name: String,
+			},
+			Frame {
+				#[msg(transferable)]
+				payload: js_sys::ArrayBuffer,
+			},
+		}
+
+		let command = Command::Init {
+			width: 100,
+			name: "test".to_string(),
+		};
+
+		let (obj, transferable) = command.clone().into_message();
+		let out = Command::from_message(obj.into()).unwrap();
+
+		assert_eq!(command, out);
+		assert_eq!(transferable.length(), 0);
+	}
+
+	#[test]
+	fn to_from_struct() {
+		#[derive(Message, Clone, Debug, PartialEq, Eq)]
+		struct Event {
+			#[msg(transferable)]
+			payload: js_sys::ArrayBuffer,
+			width: u64,
+			name: String,
+		}
+
+		let event = Event {
+			payload: js_sys::ArrayBuffer::new(100),
+			width: 100,
+			name: "test".to_string(),
+		};
+
+		let (obj, transferable) = event.clone().into_message();
+		let out = Event::from_message(obj.into()).unwrap();
+
+		assert_eq!(event, out);
+		assert_eq!(transferable, [event.payload].iter().collect());
+	}
+}

--- a/web-message/src/derive.rs
+++ b/web-message/src/derive.rs
@@ -22,7 +22,7 @@ mod test {
 
 		let mut transferable = Array::new();
 		let obj = command.clone().into_message(&mut transferable);
-		let out = Command::from_message(obj.into()).unwrap();
+		let out = Command::from_message(obj).unwrap();
 
 		assert_eq!(command, out);
 		assert_eq!(transferable.length(), 1);

--- a/web-message/src/derive.rs
+++ b/web-message/src/derive.rs
@@ -2,53 +2,51 @@ pub use web_message_derive::Message;
 
 #[cfg(test)]
 mod test {
-	use super::*;
+	use web_sys::js_sys::{Array, ArrayBuffer};
+
+	use crate::Message;
 
 	#[test]
 	fn to_from_enum() {
 		#[derive(Message, Clone, Debug, PartialEq, Eq)]
 		#[msg(tag = "command")]
 		enum Command {
-			Init {
-				width: u64,
-				name: String,
-			},
-			Frame {
-				#[msg(transferable)]
-				payload: js_sys::ArrayBuffer,
-			},
+			Connect { url: String },
+			Frame { name: Option<String>, payload: ArrayBuffer },
+			Close,
 		}
 
-		let command = Command::Init {
-			width: 100,
-			name: "test".to_string(),
+		let command = Command::Frame {
+			name: Some("test".to_string()),
+			payload: ArrayBuffer::new(100),
 		};
 
-		let (obj, transferable) = command.clone().into_message();
+		let mut transferable = Array::new();
+		let obj = command.clone().into_message(&mut transferable);
 		let out = Command::from_message(obj.into()).unwrap();
 
 		assert_eq!(command, out);
-		assert_eq!(transferable.length(), 0);
+		assert_eq!(transferable.length(), 1);
 	}
 
 	#[test]
 	fn to_from_struct() {
 		#[derive(Message, Clone, Debug, PartialEq, Eq)]
 		struct Event {
-			#[msg(transferable)]
-			payload: js_sys::ArrayBuffer,
+			payload: ArrayBuffer,
 			width: u64,
 			name: String,
 		}
 
 		let event = Event {
-			payload: js_sys::ArrayBuffer::new(100),
+			payload: ArrayBuffer::new(100),
 			width: 100,
 			name: "test".to_string(),
 		};
 
-		let (obj, transferable) = event.clone().into_message();
-		let out = Event::from_message(obj.into()).unwrap();
+		let mut transferable = Array::new();
+		let obj = event.clone().into_message(&mut transferable);
+		let out = Event::from_message(obj).unwrap();
 
 		assert_eq!(event, out);
 		assert_eq!(transferable, [event.payload].iter().collect());

--- a/web-message/src/derive.rs
+++ b/web-message/src/derive.rs
@@ -7,9 +7,8 @@ mod test {
 	use crate::Message;
 
 	#[test]
-	fn to_from_enum() {
+	fn enum_msg() {
 		#[derive(Message, Clone, Debug, PartialEq, Eq)]
-		#[msg(tag = "command")]
 		enum Command {
 			Connect { url: String },
 			Frame { name: Option<String>, payload: ArrayBuffer },
@@ -30,7 +29,7 @@ mod test {
 	}
 
 	#[test]
-	fn to_from_struct() {
+	fn struct_msg() {
 		#[derive(Message, Clone, Debug, PartialEq, Eq)]
 		struct Event {
 			payload: ArrayBuffer,
@@ -50,5 +49,33 @@ mod test {
 
 		assert_eq!(event, out);
 		assert_eq!(transferable, [event.payload].iter().collect());
+	}
+
+	#[test]
+	fn enum_variant() {
+		#[derive(Message, Clone, Debug, PartialEq, Eq)]
+		struct Config {
+			width: u32,
+			height: u32,
+		}
+
+		#[derive(Message, Clone, Debug, PartialEq, Eq)]
+		enum Command {
+			Connect { url: String },
+			Config(Config),
+			Close,
+		}
+
+		let command = Command::Config(Config {
+			width: 100,
+			height: 100,
+		});
+
+		let mut transferable = Array::new();
+		let obj = command.clone().into_message(&mut transferable);
+		let out = Command::from_message(obj).unwrap();
+
+		assert_eq!(command, out);
+		assert_eq!(transferable.length(), 1);
 	}
 }

--- a/web-message/src/error.rs
+++ b/web-message/src/error.rs
@@ -1,0 +1,20 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+	#[error("missing '{0}' field")]
+	MissingTag(&'static str),
+
+	#[error("invalid '{0}' field: {1:?}")]
+	InvalidTag(&'static str, ::js_sys::wasm_bindgen::JsValue),
+
+	#[error("unknown tag: {0} ({1:?})")]
+	UnknownTag(&'static str, ::js_sys::wasm_bindgen::JsValue),
+
+	#[error("missing '{0}' field")]
+	MissingField(&'static str),
+
+	#[error("invalid '{0}' field: {1:?}")]
+	InvalidField(&'static str, ::js_sys::wasm_bindgen::JsValue),
+
+	#[error("expected object: {0:?}")]
+	ExpectedObject(::js_sys::wasm_bindgen::JsValue),
+}

--- a/web-message/src/error.rs
+++ b/web-message/src/error.rs
@@ -1,23 +1,27 @@
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-	#[error("missing '{0}' tag")]
-	MissingTag(&'static str),
-
-	#[error("invalid '{0}' tag")]
-	InvalidTag(&'static str),
-
-	#[error("unknown tag: {0}")]
-	UnknownTag(&'static str),
-
 	#[error("missing '{0}' field")]
 	MissingField(&'static str),
 
 	#[error("invalid '{0}' field")]
 	InvalidField(&'static str),
 
-	#[error("expected object")]
-	ExpectedObject,
+	#[error("expected object with a single (string) key")]
+	ExpectedUnitObject,
+
+	#[error("expected null")]
+	ExpectedNull,
 
 	#[error("invalid type: {0}")]
 	InvalidType(&'static str),
+
+	#[error("expected string")]
+	ExpectedString,
+
+	#[error("unknown tag: {0}")]
+	UnknownTag(String),
+
+	#[cfg(feature = "url")]
+	#[error("invalid URL: {0}")]
+	InvalidUrl(url::ParseError),
 }

--- a/web-message/src/error.rs
+++ b/web-message/src/error.rs
@@ -1,20 +1,23 @@
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-	#[error("missing '{0}' field")]
+	#[error("missing '{0}' tag")]
 	MissingTag(&'static str),
 
-	#[error("invalid '{0}' field: {1:?}")]
-	InvalidTag(&'static str, ::js_sys::wasm_bindgen::JsValue),
+	#[error("invalid '{0}' tag")]
+	InvalidTag(&'static str),
 
-	#[error("unknown tag: {0} ({1:?})")]
-	UnknownTag(&'static str, ::js_sys::wasm_bindgen::JsValue),
+	#[error("unknown tag: {0}")]
+	UnknownTag(&'static str),
 
 	#[error("missing '{0}' field")]
 	MissingField(&'static str),
 
-	#[error("invalid '{0}' field: {1:?}")]
-	InvalidField(&'static str, ::js_sys::wasm_bindgen::JsValue),
+	#[error("invalid '{0}' field")]
+	InvalidField(&'static str),
 
-	#[error("expected object: {0:?}")]
-	ExpectedObject(::js_sys::wasm_bindgen::JsValue),
+	#[error("expected object")]
+	ExpectedObject,
+
+	#[error("invalid type: {0}")]
+	InvalidType(&'static str),
 }

--- a/web-message/src/lib.rs
+++ b/web-message/src/lib.rs
@@ -1,0 +1,10 @@
+// Required for derive to work.
+extern crate self as web_message;
+
+#[cfg(feature = "derive")]
+mod derive;
+#[cfg(feature = "derive")]
+pub use derive::*;
+
+mod error;
+pub use error::*;

--- a/web-message/src/lib.rs
+++ b/web-message/src/lib.rs
@@ -1,3 +1,36 @@
+//! A crate for sending and receiving messages via `postMessage`.
+//!
+//! Any type that implements [Message] can be serialized and unserialized.
+//! Unlike using Serde for JSON encoding, this approach preserves [Transferable Objects](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects) and can avoid expensive allocations and copying.
+//! Unlike using #[wasm-bindgen], this approach works outside of the `wasm-bindgen` ABI, supporting more types (ex. named enum variants).
+//!
+//! For example, the main thread can send a [js_sys::ArrayBuffer] or a Web Worker without copying the data.
+//! If the WASM worker only needs to process a few header bytes, it can use the [js_sys::ArrayBuffer] instead of copying into a [Vec<u8>].
+//! The resulting bytes can then be passed to [VideoDecoder](https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder) and the resulting [VideoFrame](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame) (transferable) can be posted back to the main thread.
+//! You can even pass around a [web_sys::MessagePort]!
+//!
+//! This crate is designed to be used in conjunction with the `web-message-derive` crate.
+//! We currently attempt parity with [ts-rs](https://docs.rs/ts-rs/latest/ts_rs/) so the resulting types can use `postMessage` directly from Typescript.
+//!
+//! ```rs
+//! // NOTE: This is not possible with `wasm-bindgen` or `wasm-bindgen-serde`
+//! #[derive(Message)]
+//! #[msg(tag = "command")]
+//! enum Command {
+//!     Connect {
+//!         url: String,
+//!     },
+//!     Frame {
+//!         keyframe: bool,
+//!         payload: js_sys::ArrayBuffer,
+//!     },
+//!     Close,
+//! }
+//! ```
+//!
+//! Some transferable types are gated behind feature flags:
+//!
+
 // Required for derive to work.
 extern crate self as web_message;
 
@@ -7,4 +40,7 @@ mod derive;
 pub use derive::*;
 
 mod error;
+mod message;
+
 pub use error::*;
+pub use message::*;

--- a/web-message/src/message.rs
+++ b/web-message/src/message.rs
@@ -146,3 +146,15 @@ transferable_feature!(
 	//"MediaSourceHandle" = MediaSourceHandle,
 	"MidiAccess" = MidiAccess,
 );
+
+#[cfg(feature = "url")]
+impl Message for url::Url {
+	fn into_message(self, _transferable: &mut Array) -> JsValue {
+		self.to_string().into()
+	}
+
+	fn from_message(message: JsValue) -> Result<Self, Error> {
+		let str = message.as_string().ok_or(Error::ExpectedString)?;
+		url::Url::parse(&str).map_err(Error::InvalidUrl)
+	}
+}

--- a/web-message/src/message.rs
+++ b/web-message/src/message.rs
@@ -57,7 +57,7 @@ impl Message for bool {
 	}
 
 	fn from_message(message: JsValue) -> Result<Self, Error> {
-		Ok(message.as_bool().ok_or(Error::InvalidType("bool"))?)
+		message.as_bool().ok_or(Error::InvalidType("bool"))
 	}
 }
 
@@ -87,7 +87,11 @@ impl<T: Message> Message for Vec<T> {
 	}
 
 	fn from_message(message: JsValue) -> Result<Self, Error> {
-		let array = Array::try_from(message).map_err(|_| Error::InvalidType("Vec"))?;
+		if !message.is_array() {
+			return Err(Error::InvalidType("Vec"));
+		}
+
+		let array = Array::from(&message);
 		let mut values = Vec::with_capacity(array.length() as usize);
 		for i in 0..array.length() {
 			values.push(T::from_message(array.get(i))?);

--- a/web-message/src/message.rs
+++ b/web-message/src/message.rs
@@ -1,0 +1,148 @@
+use js_sys::Array;
+use js_sys::wasm_bindgen;
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::js_sys;
+
+use crate::Error;
+pub trait Message: Sized {
+	// Serializes the message into a JsValue.
+	// Any transferable fields are appended to the given array.
+	fn into_message(self, transferable: &mut Array) -> JsValue;
+
+	// Deserializes the message from a JsValue.
+	fn from_message(message: JsValue) -> Result<Self, Error>;
+}
+
+macro_rules! upstream {
+	($($t:ty),*) => {
+		$(
+			impl Message for $t {
+				fn into_message(self, _transferable: &mut Array) -> JsValue {
+					self.into()
+				}
+
+				fn from_message(message: JsValue) -> Result<Self, Error> {
+					Self::try_from(message).map_err(|_| Error::InvalidType(stringify!($t)))
+				}
+			}
+		)*
+	};
+}
+
+// Macro for implementing Message for primitive casts supported in wasm-bindgen
+upstream!(String, f64, i128, i64, u128, u64);
+
+macro_rules! integer {
+	($($t:ty),*) => {
+		$(
+			impl Message for $t {
+				fn into_message(self, _transferable: &mut Array) -> JsValue {
+					self.into()
+				}
+
+				fn from_message(message: JsValue) -> Result<Self, Error> {
+					Ok(message.as_f64().ok_or(Error::InvalidType(stringify!($t)))? as $t)
+				}
+			}
+		)*
+	};
+}
+
+// Macro for implementing Message for floating point types, less than Number.MAX_SAFE_INTEGER
+integer!(u32, i32, u16, i16, u8, i8);
+
+impl Message for bool {
+	fn into_message(self, _transferable: &mut Array) -> JsValue {
+		self.into()
+	}
+
+	fn from_message(message: JsValue) -> Result<Self, Error> {
+		Ok(message.as_bool().ok_or(Error::InvalidType("bool"))?)
+	}
+}
+
+impl<T: Message> Message for Option<T> {
+	fn into_message(self, transferable: &mut Array) -> JsValue {
+		match self {
+			Some(value) => value.into_message(transferable),
+			None => JsValue::NULL,
+		}
+	}
+
+	fn from_message(message: JsValue) -> Result<Self, Error> {
+		Ok(match message.is_null() {
+			true => None,
+			false => Some(T::from_message(message)?),
+		})
+	}
+}
+
+impl<T: Message> Message for Vec<T> {
+	fn into_message(self, transferable: &mut Array) -> JsValue {
+		let array = Array::new();
+		for value in self {
+			array.push(&value.into_message(transferable));
+		}
+		array.into()
+	}
+
+	fn from_message(message: JsValue) -> Result<Self, Error> {
+		let array = Array::try_from(message).map_err(|_| Error::InvalidType("Vec"))?;
+		let mut values = Vec::with_capacity(array.length() as usize);
+		for i in 0..array.length() {
+			values.push(T::from_message(array.get(i))?);
+		}
+		Ok(values)
+	}
+}
+
+impl Message for js_sys::ArrayBuffer {
+	fn into_message(self, transferable: &mut Array) -> JsValue {
+		transferable.push(&self);
+		self.into()
+	}
+
+	fn from_message(message: JsValue) -> Result<Self, Error> {
+		message
+			.dyn_into::<js_sys::ArrayBuffer>()
+			.map_err(|_| Error::InvalidType("ArrayBuffer"))
+	}
+}
+
+macro_rules! transferable_feature {
+	($($feature:literal = $t:ident),* $(,)?) => {
+		$(
+			#[cfg(feature = $feature)]
+			impl Message for web_sys::$t {
+				fn into_message(self, transferable: &mut Array) -> JsValue {
+					transferable.push(&self);
+					self.into()
+				}
+
+				fn from_message(message: JsValue) -> Result<Self, Error> {
+					message
+						.dyn_into::<web_sys::$t>()
+						.map_err(|_| Error::InvalidType(stringify!($t)))
+				}
+			}
+		)*
+	};
+}
+
+// These feature names copy web_sys for all (currently) transferable types.
+// https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects
+transferable_feature!(
+	"MessagePort" = MessagePort,
+	"ReadableStream" = ReadableStream,
+	"WritableStream" = WritableStream,
+	"TransformStream" = TransformStream,
+	"WebTransportReceiveStream" = WebTransportReceiveStream,
+	"WebTransportSendStream" = WebTransportSendStream,
+	"AudioData" = AudioData,
+	"ImageBitmap" = ImageBitmap,
+	"VideoFrame" = VideoFrame,
+	"OffscreenCanvas" = OffscreenCanvas,
+	"RtcDataChannel" = RtcDataChannel,
+	//"MediaSourceHandle" = MediaSourceHandle,
+	"MidiAccess" = MidiAccess,
+);


### PR DESCRIPTION
Adds a way to convert to/from JsValues without serde. Useful for transferring objects that can't be JSON encoded across workers and windows. 