### PR TITLE
feat(web-async): add portable time module

### DIFF
--- a/web-async/Cargo.toml
+++ b/web-async/Cargo.toml
@@ -18,7 +18,9 @@ tracing = ["dep:tracing"]
 tracing = { version = "0.1", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1", features = ["rt", "time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
+# Browser time shim: std::time::Instant + tokio::time API on performance.now() + setTimeout.
+wasmtimer = "0.4"

--- a/web-async/src/lib.rs
+++ b/web-async/src/lib.rs
@@ -1,6 +1,7 @@
 mod futures;
 mod lock;
 mod spawn;
+pub mod time;
 
 pub use futures::*;
 pub use lock::*;

--- a/web-async/src/time.rs
+++ b/web-async/src/time.rs
@@ -1,0 +1,32 @@
+//! Portable async time: `tokio::time` on native, [`wasmtimer`] in the browser.
+//!
+//! Code that sleeps, ticks on an interval, or reads an `Instant` needs to work
+//! on both targets. Native tokio's clock is `std::time::Instant::now()`, which
+//! panics on `wasm32-unknown-unknown` (no clock), and its timers need a runtime
+//! time driver that `wasm_bindgen_futures::spawn_local` doesn't provide. So in
+//! the browser we route through `wasmtimer`, which implements the same API on
+//! `performance.now()` + `setTimeout`. Use `web_async::time` in place of
+//! `tokio::time` and the same code runs on both.
+//!
+//! The surface mirrors `tokio::time` 1:1. The mockable test clock
+//! (`tokio::time::pause`/`advance`) is intentionally not re-exported: it lives
+//! behind tokio's `test-util` feature, which must not leak into normal builds,
+//! and it only ever runs in native tests anyway.
+
+pub use std::time::Duration;
+
+// wasi has a real clock and tokio support, so it goes with native (matching the
+// cfg split in `spawn`).
+#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+pub use tokio::time::{
+	interval, interval_at, sleep, sleep_until, timeout, timeout_at, Instant, Interval, MissedTickBehavior, Sleep,
+	Timeout,
+};
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+pub use wasmtimer::{
+	std::Instant,
+	tokio::{
+		interval, interval_at, sleep, sleep_until, timeout, timeout_at, Interval, MissedTickBehavior, Sleep, Timeout,
+	},
+};


### PR DESCRIPTION
Adds `web_async::time` so code can use timers and `Instant` on both native and the browser, the same way `web_async::spawn` already abstracts task spawning.

## Why

`tokio::time` does not work on `wasm32-unknown-unknown`:

- tokio's clock is `std::time::Instant::now()`, which **panics** on wasm (no clock).
- tokio's timers need a runtime time driver, which `wasm_bindgen_futures::spawn_local` (what `web_async::spawn` uses on wasm) does not provide.

So any crate that sleeps, ticks on an interval, or reads an `Instant` currently can't compile-and-run on both targets. This came up making `moq-net` run in the browser, but it's the same problem for anything in this ecosystem.

## What

`time.rs` is a thin cfg-switched re-export mirroring `tokio::time` 1:1:

- **native / wasi:** `tokio::time::{Instant, Sleep, Interval, Timeout, MissedTickBehavior, sleep, sleep_until, interval, interval_at, timeout, timeout_at}`
- **browser wasm:** the same names from [`wasmtimer`](https://crates.io/crates/wasmtimer), which implements that API on `performance.now()` + `setTimeout`, plus `wasmtimer::std::Instant`.
- `Duration` re-exported for convenience.

Callers swap `tokio::time` for `web_async::time` and the same code runs on both.

Notes:
- `wasmtimer` is under `[target.'cfg(target_arch = "wasm32")'.dependencies]`, so native builds never pull it. Native just gains tokio's `time` feature.
- The cfg split (wasi grouped with native) matches `spawn.rs`.
- The mockable test clock (`tokio::time::pause`/`advance`) is intentionally not re-exported: it lives behind tokio's `test-util` feature, which shouldn't leak into normal builds, and only runs in native tests.

## Test

- `cargo fmt --check`, `cargo clippy -- -D warnings` clean (native).
- Builds for both host and `wasm32-unknown-unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)