### PR TITLE
fix(web-codecs): VideoFrame::timestamp returns f64 in web-sys 0.3.100

### DIFF
--- a/web-codecs/src/video/frame.rs
+++ b/web-codecs/src/video/frame.rs
@@ -14,7 +14,7 @@ pub struct VideoFrame(web_sys::VideoFrame);
 
 impl VideoFrame {
 	pub fn timestamp(&self) -> Timestamp {
-		Timestamp::from_micros(self.0.timestamp().unwrap() as _)
+		Timestamp::from_micros(self.0.timestamp() as _)
 	}
 
 	pub fn duration(&self) -> Option<Duration> {


### PR DESCRIPTION
`web-sys 0.3.100` changed `VideoFrame::timestamp()` from `Option<f64>` to `f64`, so `web-codecs/src/video/frame.rs` no longer compiles:

```
error[E0599]: no method named `unwrap` found for type `f64`
  --> web-codecs/src/video/frame.rs:17
```

Fix is to drop the `.unwrap()`.

`Cargo.lock` is gitignored (library convention), so CI resolves `web-sys` fresh to the latest on every run. That means this break blocks **all** PRs against the repo, not just one (same situation as the earlier "Update web-codecs for web-sys 0.3.91" change). Verified at `web-sys 0.3.100`: `cargo build`/`clippy -D warnings`/`fmt --check` all clean for web-codecs on `wasm32-unknown-unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)