### PR TITLE
[codex] export wasm time helpers

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ setup:
 
 # A separate entrypoint for CI.
 setup-tools:
-	cargo binstall -y cargo-shear cargo-sort cargo-upgrades cargo-edit
+	cargo binstall -y --force cargo-shear cargo-sort cargo-upgrades cargo-edit
 
 # Run the CI checks
 check:

--- a/web-async/CHANGELOG.md
+++ b/web-async/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Re-export `SystemTime` from `web_async::time` and add `MaybeSend`/`MaybeSync` future helpers.
+
 ## [0.1.4](https://github.com/kixelated/web-rs/compare/web-async-v0.1.3...web-async-v0.1.4) - 2026-06-09
 
 ### Added

--- a/web-async/Cargo.toml
+++ b/web-async/Cargo.toml
@@ -17,10 +17,10 @@ tracing = ["dep:tracing"]
 [dependencies]
 tracing = { version = "0.1", optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["rt", "time"] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 wasm-bindgen-futures = "0.4"
 # Browser time shim: std::time::Instant + tokio::time API on performance.now() + setTimeout.
-wasmtimer = "0.4"
+wasmtimer = { version = "0.4", default-features = false, features = ["tokio"] }
+
+[target.'cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))'.dependencies]
+tokio = { version = "1", features = ["rt", "time"] }

--- a/web-async/src/lib.rs
+++ b/web-async/src/lib.rs
@@ -1,8 +1,10 @@
 mod futures;
 mod lock;
+mod maybe;
 mod spawn;
 pub mod time;
 
 pub use futures::*;
 pub use lock::*;
+pub use maybe::*;
 pub use spawn::*;

--- a/web-async/src/maybe.rs
+++ b/web-async/src/maybe.rs
@@ -1,0 +1,51 @@
+use std::future::Future;
+use std::pin::Pin;
+
+#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+/// A trait that is `Send` on native/WASI targets and empty in browser WASM.
+pub trait MaybeSend: Send {}
+
+#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+impl<T: Send> MaybeSend for T {}
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+/// A trait that is `Send` on native/WASI targets and empty in browser WASM.
+pub trait MaybeSend {}
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+impl<T> MaybeSend for T {}
+
+#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+/// A trait that is `Sync` on native/WASI targets and empty in browser WASM.
+pub trait MaybeSync: Sync {}
+
+#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+impl<T: Sync> MaybeSync for T {}
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+/// A trait that is `Sync` on native/WASI targets and empty in browser WASM.
+pub trait MaybeSync {}
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+impl<T> MaybeSync for T {}
+
+#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+/// A boxed future that is `Send` on native/WASI targets and local in browser WASM.
+pub type MaybeSendBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+/// A boxed future that is `Send` on native/WASI targets and local in browser WASM.
+pub type MaybeSendBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+/// Extension helpers for boxing futures with target-appropriate `Send` bounds.
+pub trait MaybeFutureExt: Future + Sized {
+	/// Box this future with target-appropriate `Send` bounds.
+	fn maybe_boxed<'a>(self) -> MaybeSendBoxFuture<'a, Self::Output>
+	where
+		Self: MaybeSend + 'a,
+	{
+		Box::pin(self)
+	}
+}
+
+impl<F: Future> MaybeFutureExt for F {}

--- a/web-async/src/spawn.rs
+++ b/web-async/src/spawn.rs
@@ -1,22 +1,20 @@
 use std::future::Future;
 
+use crate::MaybeSend;
+
 // It's not pretty, but we have per-platform implementations of spawn.
 // The main problem is Send; it's an annoying trait that colors everything.
 // The rest of this crate is Send agnostic so it will work on WASM.
 // TODO: use a send feature and make this runtime agnostic?
 
-#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
 #[track_caller]
-pub fn spawn<F: Future<Output = ()> + Send + 'static>(f: F) {
+pub fn spawn<F: Future<Output = ()> + MaybeSend + 'static>(f: F) {
 	#[cfg(feature = "tracing")]
 	let f = tracing::Instrument::in_current_span(f);
-	tokio::task::spawn(f);
-}
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
-#[track_caller]
-pub fn spawn<F: Future<Output = ()> + 'static>(f: F) {
-	#[cfg(feature = "tracing")]
-	let f = tracing::Instrument::in_current_span(f);
+	#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+	tokio::task::spawn(f);
+
+	#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 	wasm_bindgen_futures::spawn_local(f);
 }

--- a/web-async/src/time.rs
+++ b/web-async/src/time.rs
@@ -15,18 +15,22 @@
 
 pub use std::time::Duration;
 
+#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+pub use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
+
 // wasi has a real clock and tokio support, so it goes with native (matching the
 // cfg split in `spawn`).
 #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
 pub use tokio::time::{
-	interval, interval_at, sleep, sleep_until, timeout, timeout_at, Instant, Interval, MissedTickBehavior, Sleep,
-	Timeout,
+	error::Elapsed, interval, interval_at, sleep, sleep_until, timeout, timeout_at, Instant, Interval,
+	MissedTickBehavior, Sleep, Timeout,
 };
 
 #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 pub use wasmtimer::{
-	std::Instant,
+	std::{Instant, SystemTime, SystemTimeError, UNIX_EPOCH},
 	tokio::{
-		interval, interval_at, sleep, sleep_until, timeout, timeout_at, Interval, MissedTickBehavior, Sleep, Timeout,
+		error::Elapsed, interval, interval_at, sleep, sleep_until, timeout, timeout_at, Interval, MissedTickBehavior,
+		Sleep, Timeout,
 	},
 };


### PR DESCRIPTION
## Summary

- Add `web_async::time` as a cross-target time facade.
- Export `SystemTime`/`UNIX_EPOCH` via `std::time` on native/WASI and `wasmtimer::std` on browser WASM.
- Add `MaybeSend`, `MaybeSync`, `MaybeSendBoxFuture`, and `MaybeFutureExt` helpers so downstream crates can avoid their own Send/Sync cfg switches.
- Update `spawn` to use the shared `MaybeSend` abstraction.
- Force reinstall CI cargo subcommands in `just setup-tools` so stale tool-cache metadata cannot leave `cargo shear` missing.

## Why

The MoQ browser WASM work needs a stable way to anchor timestamps without falling back to local cfg-specific clock code, and it also needs reusable Send-local helper traits for browser-only transport futures.

The previous CI run failed after check/clippy/fmt passed because `cargo binstall` reported `cargo-shear` as already installed while the `cargo shear` subcommand was absent. Forcing tool installation makes the setup step repair that cache state.

## Validation

- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `cargo shear`
- `cargo sort --workspace --check`
- `cargo check -p web-async --target aarch64-apple-darwin`
- `cargo check -p web-async --target wasm32-unknown-unknown`
- `cargo check -p web-async --features tracing --target aarch64-apple-darwin`
- `cargo check -p web-async --features tracing --target wasm32-unknown-unknown`